### PR TITLE
feat(facebook): add facebed, a embed preview for facebook posts

### DIFF
--- a/src/doctors.ts
+++ b/src/doctors.ts
@@ -90,8 +90,22 @@ const instagram: Doctor = async (url: URL): Promise<Reply[]> => {
   return [];
 };
 
+const facebook: Doctor = async (url: URL): Promise<Reply[]> => {
+  if (
+    url.hostname === 'facebook.com' ||
+    url.hostname === 'www.facebook.com'
+  ) {
+    url.hostname = url.hostname.replace('facebook.com', 'facebed.com');
+    // Although I want to invoke cleanUrl to kill all tracking variables
+    // But only found the preview no longer working if some vars are removed
+    // So it behaves conservatively here.
+    return [{ title: 'FaceBed', href: url.href }];
+  }
+  return [];
+};
+
 export const cleaner: Doctor = async (url: URL): Promise<Reply[]> => {
   return [cleanUrlReply(url)];
 };
 
-export const doctors = [bilibili, twitter, xhs, youtube, instagram];
+export const doctors = [bilibili, twitter, xhs, youtube, instagram, facebook];


### PR DESCRIPTION
This commit adds [facebed](https://facebed.com), a embed preview helper for facebook posts into Telegram.

The doctor will only replace `facebook.com` with `facebed.com` since I don't know which variables track the sharers or which variables target to the post.
When I tested facebed with this [url](https://www.facebed.com/permalink.php?story_fbid=pfbid02RaXhkDosnfDwxhViHBZ8DqczV28eLu2mpgMd1wcga86DXtYH1fQE14SHSrDYnCTsl&id=100087188520205), seems both `story_fbid` and `id` are required, even though the URL schemes in facebed refers only to `permalink.php?story_fbid`. So I was confused and decided not cleaning the URL at present.
